### PR TITLE
Add start script for running Parcel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,10 @@ Start the development server with Parcel:
 npx parcel index.html
 ```
 
+You can also use the npm script:
+
+```bash
+npm start
+```
+
 Then open the URL printed in the terminal to view the app.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "parcel index.html"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `start` script to run Parcel
- document `npm start` shortcut in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684331be70648320a9c371a5fd5ae870